### PR TITLE
bump google-github-actions/auth to 2.1.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   using: 'composite'
   steps:
     - name: Authenticate to GCP
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2.1.8
       with:
         credentials_json: ${{ inputs.gcloud_service_key }}
 


### PR DESCRIPTION
## What does this PR do?

The following change will update the version of `google-github-actions/auth` from `v1` to `v2.1.8`