### PR TITLE
feat: bump google-github-actions/setup-gcloud to 2.1.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
         credentials_json: ${{ inputs.gcloud_service_key }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2.1.4
 
     - name: Configure Docker Client for Gcloud
       run: gcloud auth configure-docker ${{ inputs.registry }} --quiet


### PR DESCRIPTION
## What does this PR do?

The following change will update the version of `google-github-actions/setup-gcloud` from `v1` to `v2.1.4`